### PR TITLE
Use angle brackets to describe required arguments

### DIFF
--- a/src/leiningen/how_to_ns.clj
+++ b/src/leiningen/how_to_ns.clj
@@ -273,7 +273,7 @@
        (mapcat #(cljfmt/find-files project %))))
 
 (def usage
-  "USAGE: lein how-to-ns [check | fix]")
+  "USAGE: lein how-to-ns <check|fix>")
 
 (defn how-to-ns
   "Lint clojure ns forms.


### PR DESCRIPTION
Hey Gary,

Not a big one, but something that will maybe make it obvious there isn't a default command when you omit one of check or fix (i.e. `lein how-to-ns`).

---

Required arguments/options are commonly wrapped in angle brackets, and optional
in square brackets.

- https://en.wikipedia.org/wiki/Command-line_interface#Command_description_syntax
- http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html