### PR TITLE
Support npm-style requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,14 @@ your `project.clj` or `:user` profile for the lein plugin, the
 following options are available, shown here with their default values:
 
 ``` clojure
-{:require-docstring?      true
- :sort-clauses?           true
- :allow-refer-all?        false
- :allow-rename?           false
- :allow-extra-clauses?    false
- :align-clauses?          false
- :import-square-brackets? false}
+{:require-docstring?               true
+ :sort-clauses?                    true
+ :allow-refer-all?                 false
+ :allow-rename?                    false
+ :allow-extra-clauses?             false
+ :align-clauses?                   false
+ :import-square-brackets?          false
+ :place-string-requires-at-bottom? false}
 ```
 
 ## Things it doesn't do until somebody makes it do them

--- a/how-to-ns/src/com/gfredericks/how_to_ns.clj
+++ b/how-to-ns/src/com/gfredericks/how_to_ns.clj
@@ -13,7 +13,7 @@
    :allow-rename?                    false
    :align-clauses?                   false
    :import-square-brackets?          false
-   :place-string-requires-at-bottom? false})
+   :sort-string-requires-to-end?     false})
 
 (defn parse-ns-form
   [[_ns-sym ns-name-sym & more]]
@@ -129,13 +129,13 @@
               (update-when :only (comp vec sort))
               (->> (apply concat))))))
 
-(defn require-sort-criterion [{:keys [place-string-requires-at-bottom?]}]
+(defn require-sort-criterion [{:keys [sort-string-requires-to-end?]}]
   (fn [x]
     (let [namespace (if (coll? x)
                       (first x)
                       x)
           criterion (str namespace)]
-      (if (and place-string-requires-at-bottom?
+      (if (and sort-string-requires-to-end?
                (string? namespace))
         (str "zzzzzz" criterion)
         criterion))))

--- a/how-to-ns/src/com/gfredericks/how_to_ns.clj
+++ b/how-to-ns/src/com/gfredericks/how_to_ns.clj
@@ -135,9 +135,8 @@
                       (first x)
                       x)
           criterion (str namespace)]
-      (if (and sort-string-requires-to-end?
-               (string? namespace))
-        (str "zzzzzz" criterion)
+      (if sort-string-requires-to-end?
+        [(if (string? namespace) 1 0) criterion]
         criterion))))
 
 (defn print-ns-form

--- a/how-to-ns/src/com/gfredericks/how_to_ns.clj
+++ b/how-to-ns/src/com/gfredericks/how_to_ns.clj
@@ -6,13 +6,14 @@
 (set! *warn-on-reflection* true)
 
 (def default-opts
-  {:require-docstring?      true
-   :sort-clauses?           true
-   :allow-refer-all?        false
-   :allow-extra-clauses?    false
-   :allow-rename?           false
-   :align-clauses?          false
-   :import-square-brackets? false})
+  {:require-docstring?               true
+   :sort-clauses?                    true
+   :allow-refer-all?                 false
+   :allow-extra-clauses?             false
+   :allow-rename?                    false
+   :align-clauses?                   false
+   :import-square-brackets?          false
+   :place-string-requires-at-bottom? false})
 
 (defn parse-ns-form
   [[_ns-sym ns-name-sym & more]]
@@ -128,6 +129,17 @@
               (update-when :only (comp vec sort))
               (->> (apply concat))))))
 
+(defn require-sort-criterion [{:keys [place-string-requires-at-bottom?]}]
+  (fn [x]
+    (let [namespace (if (coll? x)
+                      (first x)
+                      x)
+          criterion (str namespace)]
+      (if (and place-string-requires-at-bottom?
+               (string? namespace))
+        (str "zzzzzz" criterion)
+        criterion))))
+
 (defn print-ns-form
   [ns-form opts]
   (let [{:keys [ns doc refer-clojure require require-macros import gen-class extra]}
@@ -176,7 +188,7 @@
                                    (apply max))
             clauses (cond->> clauses
                       (:sort-clauses? opts)
-                      (sort-by (comp str #(if (coll? %) (first %) %)))
+                      (sort-by (require-sort-criterion opts))
                       (:align-clauses? opts)
                       (map (fn [clause]
                              (if (and (coll? clause)

--- a/how-to-ns/src/com/gfredericks/how_to_ns.clj
+++ b/how-to-ns/src/com/gfredericks/how_to_ns.clj
@@ -73,7 +73,8 @@
 (defn normalize-require
   "Returns a collection of clauses."
   [require-clause opts]
-  (let [require-clause (if (symbol? require-clause)
+  (let [require-clause (if (or (symbol? require-clause)
+                               (string? require-clause))
                          [require-clause]
                          require-clause)
         clauses (if (or (coll? (second require-clause))
@@ -175,7 +176,7 @@
                                    (apply max))
             clauses (cond->> clauses
                       (:sort-clauses? opts)
-                      (sort-by #(if (coll? %) (first %) %))
+                      (sort-by (comp str #(if (coll? %) (first %) %)))
                       (:align-clauses? opts)
                       (map (fn [clause]
                              (if (and (coll? clause)

--- a/how-to-ns/test/com/gfredericks/how_to_ns_test.clj
+++ b/how-to-ns/test/com/gfredericks/how_to_ns_test.clj
@@ -309,6 +309,28 @@
   (:require-macros
    [clojure.test]))"}])
 
+(deftest requires-processing
+  (testing "`require` clasuses are processed and sorted. npm-style ones are also handled"
+    (are [input expected] (= expected
+                             (how-to-ns/format-ns-str input {:require-docstring? false}))
+      "(ns foo)"
+      "(ns foo)"
+
+      "(ns foo (:require foo))"
+      "(ns foo\n  (:require\n   [foo]))"
+
+      "(ns foo (:require \"foo\"))"
+      "(ns foo\n  (:require\n   [\"foo\"]))"
+
+      "(ns foo (:require [\"foo\"]))"
+      "(ns foo\n  (:require\n   [\"foo\"]))"
+
+      "(ns foo (:require [\"foo\" :as bar]))"
+      "(ns foo\n  (:require\n   [\"foo\" :as bar]))"
+
+      "(ns foo (:require [\"foo\" :as bar] goofy abc))"
+      "(ns foo\n  (:require\n   [abc]\n   [\"foo\" :as bar]\n   [goofy]))")))
+
 (deftest it-works
   (doseq [{:keys [outcome opts ns-str]} test-cases]
     (is ((case outcome :good identity :bad not)

--- a/how-to-ns/test/com/gfredericks/how_to_ns_test.clj
+++ b/how-to-ns/test/com/gfredericks/how_to_ns_test.clj
@@ -309,6 +309,13 @@
   (:require-macros
    [clojure.test]))"}])
 
+(deftest require-sort-criterion
+  (are [input option expected] (= expected
+                                  (sort-by (how-to-ns/require-sort-criterion {:place-string-requires-at-bottom? option})
+                                           input))
+    '(c "b" a) false '(a "b" c)
+    '(c "b" a) true  '(a c "b")))
+
 (deftest requires-processing
   (testing "`require` clasuses are processed and sorted. npm-style ones are also handled"
     (are [input expected] (= expected
@@ -329,7 +336,20 @@
       "(ns foo\n  (:require\n   [\"foo\" :as bar]))"
 
       "(ns foo (:require [\"foo\" :as bar] goofy abc))"
-      "(ns foo\n  (:require\n   [abc]\n   [\"foo\" :as bar]\n   [goofy]))")))
+      "(ns foo\n  (:require\n   [abc]\n   [\"foo\" :as bar]\n   [goofy]))"))
+
+  (testing "`:place-string-requires-at-bottom?` option"
+    (are [option input expected] (= expected
+                                    (how-to-ns/format-ns-str input {:require-docstring? false
+                                                                    :place-string-requires-at-bottom? option}))
+
+      false
+      "(ns foo (:require [\"foo\" :as bar] goofy abc))"
+      "(ns foo\n  (:require\n   [abc]\n   [\"foo\" :as bar]\n   [goofy]))"
+
+      true
+      "(ns foo (:require [\"foo\" :as bar] goofy abc))"
+      "(ns foo\n  (:require\n   [abc]\n   [goofy]\n   [\"foo\" :as bar]))")))
 
 (deftest it-works
   (doseq [{:keys [outcome opts ns-str]} test-cases]

--- a/how-to-ns/test/com/gfredericks/how_to_ns_test.clj
+++ b/how-to-ns/test/com/gfredericks/how_to_ns_test.clj
@@ -311,7 +311,7 @@
 
 (deftest require-sort-criterion
   (are [input option expected] (= expected
-                                  (sort-by (how-to-ns/require-sort-criterion {:place-string-requires-at-bottom? option})
+                                  (sort-by (how-to-ns/require-sort-criterion {:sort-string-requires-to-end? option})
                                            input))
     '(c "b" a) false '(a "b" c)
     '(c "b" a) true  '(a c "b")))
@@ -338,10 +338,10 @@
       "(ns foo (:require [\"foo\" :as bar] goofy abc))"
       "(ns foo\n  (:require\n   [abc]\n   [\"foo\" :as bar]\n   [goofy]))"))
 
-  (testing "`:place-string-requires-at-bottom?` option"
+  (testing "`:sort-string-requires-to-end?` option"
     (are [option input expected] (= expected
                                     (how-to-ns/format-ns-str input {:require-docstring? false
-                                                                    :place-string-requires-at-bottom? option}))
+                                                                    :sort-string-requires-to-end? option}))
 
       false
       "(ns foo (:require [\"foo\" :as bar] goofy abc))"


### PR DESCRIPTION
Fixes #11

As the test expresses, I went for this kind of sorting:

```clojure
(ns foo
  (:require
   [abc]
   ["foo" :as bar]
   [goofy]))
```

i.e. this sorting doesn't leave all "npm requires" at the bottom:


```clojure
(ns foo
  (:require
   [abc]
   [goofy]
   ["foo" :as bar]))
```

Personally I would tend to care about names (`foo`, `abc`) more than provenance. The alternative seems perfectly reasonable though.

---

An interesting related read:

https://code.thheller.com/blog/shadow-cljs/2019/03/01/what-shadow-cljs-is-and-isnt.html

> ...people mistakenly think that (:require ["foo/bar" :as x]) is something shadow-cljs specific when it is absolutely not.

Cheers - V