### PR TITLE
Add basic support for conditional :import

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,8 @@ following options are available, shown here with their default values:
 ## Things it doesn't do until somebody makes it do them
 
 - preserve comments or any other irregular whitespace
-- support cljc
-  - clojure's reader supports this via `{:read-cond :preserve}`, but we would also
-    need to know what formatting to target, especially since a conditional can show
-    up at any level
-    - one idea is to only allow them as direct children of the `:require`/etc forms
+- rich support for .cljc
+  - There's some basic/preliminary support for reader conditionals now, although it's not particularly prettified or canonical.
 
 ## License
 

--- a/how-to-ns/test/com/gfredericks/how_to_ns_test.clj
+++ b/how-to-ns/test/com/gfredericks/how_to_ns_test.clj
@@ -362,7 +362,7 @@
 
 (deftest reformatting
   (are [input expected] (= expected
-                            (how-to-ns/format-ns-str input {:require-docstring? false}))
+                           (how-to-ns/format-ns-str input {:require-docstring? false}))
     "(ns foo)"
     "(ns foo)"
 
@@ -406,7 +406,10 @@
     "(ns foo\n  (:import\n   (#?(:clj foo :cljs bar) baz)))"
 
     "(ns foo (:import (Foo #?(:clj bar :cljs baz) d)))"
-    "(ns foo\n  (:import\n   (Foo #?(:clj bar :cljs baz) d)))"))
+    "(ns foo\n  (:import\n   (Foo #?(:clj bar :cljs baz) d)))"
+    
+    "(ns foo #?(:clj (:import (A))))"
+    "(ns foo\n  #?(:clj (:import (A))))"))
 
 (defspec judgment-unaffected-by-arbitrary-contents-following-ns-str 500
   (prop/for-all [{:keys [opts ns-str]} (gen/elements test-cases)


### PR DESCRIPTION
I found myself writing the following code the other day:

```clojure
#?(:clj (:import
           (clojure.lang IMeta)))
```

and the recent improvements wouldn't cover that case. Here's my stab at it

Cheers - V