### PR TITLE
Support ordering of :import classes

### DIFF
--- a/how-to-ns/src/com/gfredericks/how_to_ns.clj
+++ b/how-to-ns/src/com/gfredericks/how_to_ns.clj
@@ -139,6 +139,11 @@
          (sort-by (fn [[x]]
                     (pr-str x)))
          (map (fn [[package sym-pairs]]
+                [package
+                 (vec (sort-by (fn [[packge sym]]
+                                 (print-str sym))
+                               sym-pairs))]))
+         (map (fn [[package sym-pairs]]
                 (if (reader-conditional? package)
                   package
                   (apply (if (:import-square-brackets? opts)

--- a/how-to-ns/test/com/gfredericks/how_to_ns_test.clj
+++ b/how-to-ns/test/com/gfredericks/how_to_ns_test.clj
@@ -233,7 +233,7 @@
     "(ns thomas
   \"docstring\"
   (:import
-   (java.io InputStream)
+   (java.io File InputStream)
    (java.util Random)))"}
 
    ;; unsorted imports
@@ -245,6 +245,15 @@
   (:import
    (java.util Random)
    (java.io InputStream)))"}
+
+   ;; unsorted imports classes
+   {:outcome :bad
+    :opts {}
+    :ns-str
+    "(ns thomas
+  \"docstring\"
+  (:import
+   (java.io InputStream File)))"}
 
    ;; sorted exclude
    {:outcome :good
@@ -384,8 +393,8 @@
     "(ns foo (:require #?(:clj foo :cljs bar) THING #?(:clj baz :cljs quux) OTHER))"
     "(ns foo\n  (:require\n   [OTHER]\n   [THING]\n   #?(:clj foo :cljs bar)\n   #?(:clj baz :cljs quux)))"
 
-    "(ns foo (:import (A2 a) (A1 b)))"
-    "(ns foo\n  (:import\n   (A1 b)\n   (A2 a)))"
+    "(ns foo (:import (A2 a b) (A1 b a)))"
+    "(ns foo\n  (:import\n   (A1 a b)\n   (A2 a b)))"
 
     "(ns foo (:import #?(:clj foo :cljs bar)))"
     "(ns foo\n  (:import\n   #?(:clj foo :cljs bar)))"


### PR DESCRIPTION
Stuart Sierra’s Style Guide states that "within an `:import` prefix list, [we should] sort
class names lexicographically". This PR adds support for ordering classes inside
an import list.