### PR TITLE
Add basic support for attr-map

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ following options are available, shown here with their default values:
 
 ## License
 
-Copyright © 2016 Gary Fredericks
+Copyright © 2016-2021 Gary Fredericks
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.

--- a/how-to-ns/test/com/gfredericks/how_to_ns_test.clj
+++ b/how-to-ns/test/com/gfredericks/how_to_ns_test.clj
@@ -436,7 +436,22 @@
     "(ns foo\n  (:require\n   [bar #?(:cljs :refer-macros :clj :refer) [a b]]))"
 
     "(ns foo (:require [bar :refer-macros [d c] :refer [b a]]))"
-    "(ns foo\n  (:require\n   [bar :refer [a b] :refer-macros [c d]]))"))
+    "(ns foo\n  (:require\n   [bar :refer [a b] :refer-macros [c d]]))"
+
+    "(ns foo {:doc \"I should be double-quoted\"})"
+    "(ns foo\n  {:doc \"I should be double-quoted\"})"
+
+    "(ns foo {:doc \"I should be double-quoted\"} (:require a))"
+    "(ns foo\n  {:doc \"I should be double-quoted\"}\n  (:require\n   [a]))"
+
+    "(ns foo \"The docstring\" {:additional 42} (:require a))"
+    "(ns foo\n  \"The docstring\"\n  {:additional 42}\n  (:require\n   [a]))"
+
+    "(ns foo {:doc \"I should be double-quoted\" :e :second})"
+    "(ns foo\n  {:doc \"I should be double-quoted\"\n   :e :second})"
+    
+    "(ns foo {:doc \"I should be double-quoted\" :e :second :f 3})"
+    "(ns foo\n  {:doc \"I should be double-quoted\"\n   :e :second\n   :f 3})"))
 
 (defspec judgment-unaffected-by-arbitrary-contents-following-ns-str 500
   (prop/for-all [{:keys [opts ns-str]} (gen/elements test-cases)


### PR DESCRIPTION
Fixes #6

Offers a basic support for attr-map. As with the readerconditionals addition, this is a simple best-effort feature that may not exactly honor the input's original format, or emit a canonically formatted output.