### PR TITLE
Implement `:traditional-newline-style?` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ following options are available, shown here with their default values:
  :allow-extra-clauses?             false
  :align-clauses?                   false
  :import-square-brackets?          false
- :place-string-requires-at-bottom? false}
+ :place-string-requires-at-bottom? false
+ ;; if `true`, doesn't place a newline after `(:require`:
+ :traditional-newline-style?       false}
 ```
 
 ## Things it doesn't do until somebody makes it do them

--- a/how-to-ns/src/com/gfredericks/how_to_ns.clj
+++ b/how-to-ns/src/com/gfredericks/how_to_ns.clj
@@ -14,7 +14,8 @@
    :allow-rename?                    false
    :align-clauses?                   false
    :import-square-brackets?          false
-   :sort-string-requires-to-end?     false})
+   :sort-string-requires-to-end?     false
+   :traditional-newline-style?       false})
 
 (defn parse-ns-form
   [[_ns-sym ns-name-sym & more]]
@@ -187,6 +188,7 @@
   [ns-form opts]
   (let [{:keys [ns doc refer-clojure require require-macros import reader-conditionals gen-class extra]}
         (parse-ns-form ns-form)
+        {:keys [traditional-newline-style?]} opts
         doc (or doc (if (:require-docstring? opts) "Perfunctory docstring."))
         ns-meta (meta ns)
         ns-meta-str (if ns-meta
@@ -223,7 +225,9 @@
             :let [clauses (normalize-fn (rest expr))]
             :when (seq clauses)]
 
-      (printf "\n  (:%s\n" name)
+      (printf "\n  (:%s%s" name (if traditional-newline-style?
+                                  ""
+                                  "\n"))
       (let [name-field-length (->> clauses
                                    (remove reader-conditional?)
                                    (map first)
@@ -245,12 +249,26 @@
                                  (if (vector? clause)
                                    (assoc clause 0 new-sym)
                                    (cons new-sym (rest clause))))
-                               clause))))]
-        (doseq [clause (butlast clauses)]
-          (print "   ")
-          (prn clause))
-        (print "   ")
-        (pr (last clauses))
+                               clause))))
+            sep (if traditional-newline-style?
+                  (->> " "
+                       (repeat (+ 5 (count name)))
+                       (apply str))
+                  "   ")]
+        (print (if traditional-newline-style?
+                 " "
+                 "   "))
+        ((if (-> clauses count (> 1))
+           prn
+           pr)
+         (first clauses))
+        (let [corpus (rest clauses)]
+          (doseq [[f clause] (partition 2 (interleave (concat (repeat (dec (count corpus))
+                                                                      prn)
+                                                              (list pr))
+                                                      corpus))]
+            (print sep)
+            (f clause)))
         (print ")")))
     (doseq [reader-conditional reader-conditionals]
       (print "\n  ")

--- a/how-to-ns/test/com/gfredericks/how_to_ns_test.clj
+++ b/how-to-ns/test/com/gfredericks/how_to_ns_test.clj
@@ -438,6 +438,22 @@
     "(ns foo (:require [bar :refer-macros [d c] :refer [b a]]))"
     "(ns foo\n  (:require\n   [bar :refer [a b] :refer-macros [c d]]))"))
 
+(deftest traditional-newline-style
+  (are [input expected] (= expected
+                           (how-to-ns/format-ns-str input {:require-docstring? false
+                                                           :traditional-newline-style? true}))
+    "(ns foo (:require foo))"
+    "(ns foo\n  (:require [foo]))"
+
+    "(ns foo (:require foo bar))"
+    "(ns foo\n  (:require [bar]\n            [foo]))"
+    
+    "(ns foo (:require foo bar baz))"
+    "(ns foo\n  (:require [bar]\n            [baz]\n            [foo]))"
+
+    "(ns foo (:require foo bar baz) (:import (java.io File) (java.util UUID)))"
+    "(ns foo\n  (:require [bar]\n            [baz]\n            [foo])\n  (:import (java.io File)\n           (java.util UUID)))"))
+
 (defspec judgment-unaffected-by-arbitrary-contents-following-ns-str 500
   (prop/for-all [{:keys [opts ns-str]} (gen/elements test-cases)
                  aftergarbage gen/string]


### PR DESCRIPTION
This makes it easier to transition from codebases using a "traditional" newline style.

Specifically, one could write a how-to-ns wrapper that would dynamically set `:traditional-newline-style?` depending on the existing style for the given file. That one way _preserves_ the existing style whatever it was, favoring smaller Git diffs.