### PR TITLE
Add argument to make cursive-style indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ following options are available, shown here with their default values:
  :import-square-brackets?          false
  :place-string-requires-at-bottom? false
  ;; if `true`, doesn't place a newline after `(:require`:
- :traditional-newline-style?       false}
+ :traditional-newline-style?       false
+ ;; if `true` make `(:require\n  <add-one-more-space-symbol-here>[clojure.string :as ...`
+ ;; This option only has effect with `:traditional-newline-style?` set to false
+ :cursive-indentation?             false}
 ```
 
 ## Things it doesn't do until somebody makes it do them

--- a/how-to-ns/src/com/gfredericks/how_to_ns.clj
+++ b/how-to-ns/src/com/gfredericks/how_to_ns.clj
@@ -18,7 +18,8 @@
    :align-clauses?                   false
    :import-square-brackets?          false
    :sort-string-requires-to-end?     false
-   :traditional-newline-style?       false})
+   :traditional-newline-style?       false
+   :cursive-indentation?             false})
 
 (defn parse-ns-form
   [[_ns-sym ns-name-sym & more]]
@@ -193,7 +194,7 @@
   [ns-form opts]
   (let [{:keys [ns doc refer-clojure require require-macros import reader-conditionals gen-class extra attr-map]}
         (parse-ns-form ns-form)
-        {:keys [traditional-newline-style?]} opts
+        {:keys [traditional-newline-style? cursive-indentation?]} opts
         doc (or doc (if (:require-docstring? opts) "Perfunctory docstring."))
         ns-meta (meta ns)
         ns-meta-str (if ns-meta
@@ -277,10 +278,14 @@
                   (->> " "
                        (repeat (+ 5 (count name)))
                        (apply str))
-                  "   ")]
+                  (if cursive-indentation?
+                    "    "
+                    "   "))]
         (print (if traditional-newline-style?
                  " "
-                 "   "))
+                 (if cursive-indentation?
+                   "    "
+                   "   ")))
         ((if (-> clauses count (> 1))
            prn
            pr)

--- a/how-to-ns/test/com/gfredericks/how_to_ns_test.clj
+++ b/how-to-ns/test/com/gfredericks/how_to_ns_test.clj
@@ -469,6 +469,33 @@
     "(ns foo (:require foo bar baz) (:import (java.io File) (java.util UUID)))"
     "(ns foo\n  (:require [bar]\n            [baz]\n            [foo])\n  (:import (java.io File)\n           (java.util UUID)))"))
 
+(deftest cursive-indentation
+  (are [input expected] (= expected
+                           (how-to-ns/format-ns-str input {:require-docstring? false
+                                                           :cursive-indentation? true}))
+    "(ns foo (:require foo))"
+    "(ns foo\n  (:require\n    [foo]))"
+
+    "(ns foo (:require foo bar))"
+    "(ns foo\n  (:require\n    [bar]\n    [foo]))"
+
+    "(ns foo (:require foo bar baz))"
+    "(ns foo\n  (:require\n    [bar]\n    [baz]\n    [foo]))"
+
+    "(ns foo (:require foo bar baz) (:import (java.io File) (java.util UUID)))"
+    "(ns foo\n  (:require\n    [bar]\n    [baz]\n    [foo])\n  (:import\n    (java.io File)\n    (java.util UUID)))")
+
+  (are [input expected] (= expected
+                           (how-to-ns/format-ns-str input {:require-docstring? false
+                                                           :traditional-newline-style? true
+                                                           :cursive-indentation? true}))
+
+    "(ns foo (:require foo bar baz))"
+    "(ns foo\n  (:require [bar]\n            [baz]\n            [foo]))"
+
+    "(ns foo (:require foo bar baz) (:import (java.io File) (java.util UUID)))"
+    "(ns foo\n  (:require [bar]\n            [baz]\n            [foo])\n  (:import (java.io File)\n           (java.util UUID)))"))
+
 (deftest as-alias
   (let [v "(ns foo\n  (:require\n   [foo :as-alias f]))"]
     (is (= v


### PR DESCRIPTION
> if two spaces should be used instead, unless the first thing in the list (not counting metadata) is a data structure literal. This should replicate Cursive's default behaviour.

Quote from cljfmt [readme](https://github.com/weavejester/cljfmt). The current behavior breaks the indentation that [Cursive](https://cursive-ide.com/) sets by default. For those teams that work primarily with cursive and idea (like the company I work for), this would be a good help to be able to integrate your amazing tool into their workflow.

@gfredericks 
